### PR TITLE
remove hardcoded control port

### DIFF
--- a/roles/gitlab-docker/templates/gitlab.rb.j2
+++ b/roles/gitlab-docker/templates/gitlab.rb.j2
@@ -4,8 +4,6 @@
 #
 external_url 'https://{{ server_name }}'
 
-gitlab_rails['gitlab_shell_ssh_port'] = 10022
-
 #### Change the initial default admin password and shared runner registraion
 #tokens.
 #####! **Only applicable on initial setup, changing these settings after database


### PR DESCRIPTION
Apparently a hardcoded control port 10022 slipped back after removal. Remove it again.