### PR TITLE
Mount the registry disk in the Docker container

### DIFF
--- a/roles/gitlab-docker/tasks/gitlab_docker.yml
+++ b/roles/gitlab-docker/tasks/gitlab_docker.yml
@@ -18,7 +18,7 @@
       - "/srv/gitlab/config:/etc/gitlab:Z"
       - "/srv/gitlab/logs:/var/log/gitlab:Z"
       - "/srv/gitlab/data:/var/opt/gitlab:Z"
-      - "/srv/gitlab/data:/var/opt/gitlab:Z"
+      - "/srv/gitlab/registry:/var/opt/gitlab/gitlab-rails/shared/registry:Z"
       - "/srv/gitlab/config/backups:/secret/gitlab/backups:Z"
   become: True
 


### PR DESCRIPTION
The registry disk was not being mounted for the Docker registry, so
Docker images were being stored in the container filesystem. Add the
mount.