### PR TITLE
Skip registry backups, fix backup cleanup

### DIFF
--- a/roles/backup/tasks/main.yml
+++ b/roles/backup/tasks/main.yml
@@ -91,5 +91,5 @@
     name: remove old backup files
     minute: 30
     hour: 5
-    job: tmpwatch -u 10d /backup/secret/ /backup/data/
+    job: tmpwatch -m 10d /backup/secret/ /backup/data/
   become: yes

--- a/roles/gitlab-docker/tasks/setup_backup.yml
+++ b/roles/gitlab-docker/tasks/setup_backup.yml
@@ -8,12 +8,12 @@
   cron:
     name: create a user data backup
     special_time: daily
-    job: docker exec -t gitlab gitlab-rake gitlab:backup:create
+    job: docker exec -t gitlab gitlab-rake gitlab:backup:create SKIP=registry
 
 - name: add old backup file cleanup to root crontab
   cron:
     name: remove old backup files
     minute: 30
     hour: 5
-    job: tmpwatch -u 14d /srv/gitlab/data/backups /srv/gitlab/config/backups
+    job: tmpwatch -m 10d /srv/gitlab/data/backups /srv/gitlab/config/backups
   become: yes


### PR DESCRIPTION
The registry on GitLab is the component that takes up the most space,
but the registry images are actually not that valuable since they are
mostly just built for testing in pipelines. The registry in GitLab
should not be used for sharing images publicly or archiving old images -
it should exist only to serve pipelines. With that in mind, let's not
create backups of the registry images.

Also fix the tmpwatch that runs via crontab to clean up old backups.
Previously we used access time as the basis for cleaning up old backup
files, but this is not so great because updatedb regularly scans files
on the server, as noted in the tmpwatch man page:

"Note that the periodic updatedb file system scans keep the atime of
directories recent."

Change the tmpwatch commands so that they use file modification time
instead (-m).