### PR TITLE
Make email Reply-To address configurable

### DIFF
--- a/roles/gitlab-docker/templates/gitlab.rb.j2
+++ b/roles/gitlab-docker/templates/gitlab.rb.j2
@@ -15,8 +15,8 @@ gitlab_rails['initial_root_password'] = '{{ gitlab_root_password }}'
 gitlab_rails['smtp_enable'] = true
 gitlab_rails['smtp_address'] = 'smtp.sdn.csc.fi'
 
-
 gitlab_rails['gitlab_email_from'] = '{{ gitlab_email_from }}'
+gitlab_rails['gitlab_email_reply_to'] = '{{ gitlab_email_reply_to|default(gitlab_email_from) }}'
 gitlab_rails['gitlab_email_display_name'] = '{{ gitlab_email_display_name }}'
 
 gitlab_rails['initial_shared_runners_registration_token'] = '{{ initial_shared_runners_registration_token }}'


### PR DESCRIPTION
Set the value of the Reply-To header in messages sent by GitLab via
config. Default to the same address that is used in the From header.